### PR TITLE
add GPU rendering doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ import subprocess
 if subprocess.run('nvidia-smi').returncode:
   raise RuntimeError(
       'Cannot communicate with GPU. '
-      'Make sure you are using a GPU Colab runtime. '
+      'Make sure you are using a GPU runtime. '
       'Go to the Runtime menu and select Choose runtime type.'
   )
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ if subprocess.run('nvidia-smi').returncode:
   )
 
 # Add an ICD config so that glvnd can pick up the Nvidia EGL driver.
-# This is usually installed as part of an Nvidia driver package, but the Colab
+# This is usually installed as part of an Nvidia driver package, but the
 # kernel doesn't install its driver via APT, and as a result the ICD is missing.
 # (https://github.com/NVIDIA/libglvnd/blob/master/src/EGL/icd_enumeration.md)
 NVIDIA_ICD_CONFIG_PATH = '/usr/share/glvnd/egl_vendor.d/10_nvidia.json'


### PR DESCRIPTION
tha's the fix @Cadene !
## What this does
This PR adds a section to the docs to help users avoid silent CPU fallback during MuJoCo rendering by configuring EGL properly. It includes a Python snippet to:

Ensure GPU is accessible (nvidia-smi)

Patch missing EGL ICD config

Verify MuJoCo GPU rendering

(Optional) Enable Triton GEMM for faster execution

Helps improve rendering speed and stability, especially on Dockerfile/Colab or headless servers.